### PR TITLE
Only require a non-empty password on sign-in

### DIFF
--- a/lib/app/sign_in/email_password_sign_in_model.dart
+++ b/lib/app/sign_in/email_password_sign_in_model.dart
@@ -78,6 +78,13 @@ class EmailPasswordSignInModel with EmailAndPasswordValidators, ChangeNotifier {
     notifyListeners();
   }
 
+  String get passwordLabelText {
+    if (formType == EmailPasswordSignInFormType.register) {
+      return Strings.password8CharactersLabel;
+    }
+    return Strings.passwordLabel;
+  }
+
   // Getters
   String get primaryButtonText {
     return <EmailPasswordSignInFormType,String>{
@@ -124,7 +131,10 @@ class EmailPasswordSignInModel with EmailAndPasswordValidators, ChangeNotifier {
   }
 
   bool get canSubmitPassword {
-    return passwordSubmitValidator.isValid(password);
+    if (formType == EmailPasswordSignInFormType.register) {
+      return passwordRegisterSubmitValidator.isValid(password);
+    }
+    return passwordSignInSubmitValidator.isValid(password);
   }
 
   bool get canSubmit {

--- a/lib/app/sign_in/email_password_sign_in_page.dart
+++ b/lib/app/sign_in/email_password_sign_in_page.dart
@@ -116,7 +116,7 @@ class _EmailPasswordSignInPageState extends State<EmailPasswordSignInPage> {
       controller: _passwordController,
       focusNode: _passwordFocusNode,
       decoration: InputDecoration(
-        labelText: Strings.passwordLabel,
+        labelText: model.passwordLabelText,
         errorText: model.passwordErrorText,
         enabled: !model.isLoading,
       ),

--- a/lib/app/sign_in/validator.dart
+++ b/lib/app/sign_in/validator.dart
@@ -79,5 +79,6 @@ class EmailAndPasswordValidators {
   final TextInputFormatter emailInputFormatter =
       ValidatorInputFormatter(editingValidator: EmailEditingRegexValidator());
   final StringValidator emailSubmitValidator = EmailSubmitRegexValidator();
-    final StringValidator passwordSubmitValidator = MinLengthStringValidator(8);
+  final StringValidator passwordRegisterSubmitValidator = MinLengthStringValidator(8);
+  final StringValidator passwordSignInSubmitValidator = NonEmptyStringValidator();
 }

--- a/lib/constants/strings.dart
+++ b/lib/constants/strings.dart
@@ -33,7 +33,8 @@ class Strings {
   static const String resetLinkSentMessage = 'Check your email to reset your password';
   static const String emailLabel = 'Email';
   static const String emailHint = 'test@test.com';
-  static const String passwordLabel = 'Password (8+ characters)';
+  static const String password8CharactersLabel = 'Password (8+ characters)';
+  static const String passwordLabel = 'Password';
   static const String invalidEmailErrorText = 'Email is invalid';
   static const String invalidEmailEmpty = 'Email can\'t be empty';
   static const String invalidPasswordTooShort = 'Password is too short';


### PR DESCRIPTION
Minimum password length of 8 characters only enforced when registering.

Fixes #10.