### PR TITLE
Update app to use ProxyProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.2
+
+- Update app to use ProxyProvider ([#14](https://github.com/bizz84/firebase_auth_demo_flutter/pull/14))
+
 # 0.0.1
 
 ## FirebaseAuth features

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,21 +8,24 @@ import 'package:provider/provider.dart';
 void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
-  final AuthServiceFacade authServiceFacade = AuthServiceFacade();
   @override
   Widget build(BuildContext context) {
-    return Provider<AuthService>(
-      builder: (_) => authServiceFacade,
-      dispose: (_, AuthService facade) => authServiceFacade.dispose(),
-      child: Provider<AuthServiceTypeBloc>(
-        builder: (_) => AuthServiceTypeBloc(authServiceFacade: authServiceFacade),
-        dispose: (_, AuthServiceTypeBloc bloc) => bloc.dispose(),
-        child: MaterialApp(
-          theme: ThemeData(
-            primarySwatch: Colors.indigo,
-          ),
-          home: LandingPage(),
+    return MultiProvider(
+      providers: <SingleChildCloneableWidget>[
+        Provider<AuthService>(
+          builder: (_) => AuthServiceFacade(),
+          dispose: (_, AuthService authService) => authService.dispose(),
         ),
+        ProxyProvider<AuthService, AuthServiceTypeBloc>(
+          builder: (_, AuthService authService, __) => AuthServiceTypeBloc(authServiceFacade: authService),
+          dispose: (_, AuthServiceTypeBloc bloc) => bloc.dispose(),
+        ),
+      ],
+      child: MaterialApp(
+        theme: ThemeData(
+          primarySwatch: Colors.indigo,
+        ),
+        home: LandingPage(),
       ),
     );
   }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -23,4 +23,5 @@ abstract class AuthService {
   Future<User> signInWithFacebook();
   Future<void> signOut();
   Stream<User> get onAuthStateChanged;
+  void dispose();
 }

--- a/lib/services/auth_service_facade.dart
+++ b/lib/services/auth_service_facade.dart
@@ -42,10 +42,12 @@ class AuthServiceFacade implements AuthService {
     });
   }
 
+  @override
   void dispose() {
     _firebaseAuthSubscription?.cancel();
     _mockAuthSubscription?.cancel();
     _onAuthStateChangedController?.close();
+    _mockAuthService.dispose();
   }
 
   final StreamController<User> _onAuthStateChangedController = StreamController<User>();

--- a/lib/services/firebase_auth_service.dart
+++ b/lib/services/firebase_auth_service.dart
@@ -97,4 +97,7 @@ class FirebaseAuthService implements AuthService {
     await facebookLogin.logOut();
     return _firebaseAuth.signOut();
   }
+
+  @override
+  void dispose() {}
 }

--- a/lib/services/mock_auth_service.dart
+++ b/lib/services/mock_auth_service.dart
@@ -113,4 +113,9 @@ class MockAuthService implements AuthService {
     _add(user);
     return user;
   }
+
+  @override
+  void dispose() {
+    _onAuthStateChangedController.close();
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: Reference Authentication Flow with Flutter & Firebase
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.0.1
+version: 0.0.2
 
 environment:
   sdk: ">=2.2.2 <3.0.0"


### PR DESCRIPTION
Use `main.dart` to use `MultiProvider` & `ProxyProvider` as a replacement for the previous nested Provider approach.