### PR TITLE
Only update loading state ValueNotifier when authentication calls fail

### DIFF
--- a/lib/app/sign_in/email_password/email_password_sign_in_model.dart
+++ b/lib/app/sign_in/email_password/email_password_sign_in_model.dart
@@ -38,13 +38,13 @@ class EmailPasswordSignInModel with EmailAndPasswordValidators, ChangeNotifier {
           break;
         case EmailPasswordSignInFormType.forgotPassword:
           await auth.sendPasswordResetEmail(email);
+          updateWith(isLoading: false);
           break;
       }
       return true;
     } catch (e) {
-      rethrow;
-    } finally {
       updateWith(isLoading: false);
+      rethrow;
     }
   }
 
@@ -105,7 +105,8 @@ class EmailPasswordSignInModel with EmailAndPasswordValidators, ChangeNotifier {
     return <EmailPasswordSignInFormType, EmailPasswordSignInFormType>{
       EmailPasswordSignInFormType.register: EmailPasswordSignInFormType.signIn,
       EmailPasswordSignInFormType.signIn: EmailPasswordSignInFormType.register,
-      EmailPasswordSignInFormType.forgotPassword: EmailPasswordSignInFormType.signIn,
+      EmailPasswordSignInFormType.forgotPassword:
+          EmailPasswordSignInFormType.signIn,
     }[formType];
   }
 
@@ -138,19 +139,25 @@ class EmailPasswordSignInModel with EmailAndPasswordValidators, ChangeNotifier {
 
   bool get canSubmit {
     final bool canSubmitFields =
-        formType == EmailPasswordSignInFormType.forgotPassword ? canSubmitEmail : canSubmitEmail && canSubmitPassword;
+        formType == EmailPasswordSignInFormType.forgotPassword
+            ? canSubmitEmail
+            : canSubmitEmail && canSubmitPassword;
     return canSubmitFields && !isLoading;
   }
 
   String get emailErrorText {
     final bool showErrorText = submitted && !canSubmitEmail;
-    final String errorText = email.isEmpty ? Strings.invalidEmailEmpty : Strings.invalidEmailErrorText;
+    final String errorText = email.isEmpty
+        ? Strings.invalidEmailEmpty
+        : Strings.invalidEmailErrorText;
     return showErrorText ? errorText : null;
   }
 
   String get passwordErrorText {
     final bool showErrorText = submitted && !canSubmitPassword;
-    final String errorText = password.isEmpty ? Strings.invalidPasswordEmpty : Strings.invalidPasswordTooShort;
+    final String errorText = password.isEmpty
+        ? Strings.invalidPasswordEmpty
+        : Strings.invalidPasswordTooShort;
     return showErrorText ? errorText : null;
   }
 

--- a/lib/app/sign_in/email_password/email_password_sign_in_page.dart
+++ b/lib/app/sign_in/email_password/email_password_sign_in_page.dart
@@ -70,7 +70,7 @@ class _EmailPasswordSignInPageState extends State<EmailPasswordSignInPage> {
       final bool success = await model.submit();
       if (success) {
         if (model.formType == EmailPasswordSignInFormType.forgotPassword) {
-          PlatformAlertDialog(
+          await PlatformAlertDialog(
             title: Strings.resetLinkSentTitle,
             content: Strings.resetLinkSentMessage,
             defaultActionText: Strings.ok,

--- a/lib/app/sign_in/sign_in_manager.dart
+++ b/lib/app/sign_in/sign_in_manager.dart
@@ -14,9 +14,8 @@ class SignInManager {
       isLoading.value = true;
       return await signInMethod();
     } catch (e) {
-      rethrow;
-    } finally {
       isLoading.value = false;
+      rethrow;
     }
   }
 

--- a/test/sign_in_manager_test.dart
+++ b/test/sign_in_manager_test.dart
@@ -50,12 +50,12 @@ void main() {
   test(
       'WHEN manager signs in anonymously'
       'AND auth returns valid user'
-      'THEN isLoading values are [ true, false ]', () async {
+      'THEN isLoading values are [ true ]', () async {
     stubSignInAnonymouslyReturnsUser();
 
     await manager.signInAnonymously();
 
-    expect(isLoading.values, <bool>[true, false]);
+    expect(isLoading.values, <bool>[true]);
   });
 
   test(


### PR DESCRIPTION
This is to prevent exceptions when updating the ValueNotifier after the parent widget is disposed following a successful sign in.